### PR TITLE
Allow to opt out of zeroize dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ readme = "README.md"
 keywords = ["cng", "windows", "cryptoapi"]
 categories = ["api-bindings", "os::windows-apis", "cryptography"]
 license = "BSD-3-Clause"
+
+[badges]
 maintenance = { status = "experimental" }
 
 [dependencies]
 winapi = { version = "0.3", features = ["bcrypt", "ntstatus"] }
-zeroize = { version = "1", optional = true }
+zeroize = { version = "1.1", optional = true }
 
 [features]
 default = ["zeroize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 winapi = { version = "0.3", features = ["bcrypt", "ntstatus"] }
-zeroize = "0.10"
+zeroize = { version = "1", optional = true }
+
+[features]
+default = ["zeroize"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -45,6 +45,10 @@ impl Buffer {
         self.inner.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
     pub fn as_ptr(&self) -> *const u8 {
         self.inner.as_ptr()
     }
@@ -55,6 +59,10 @@ impl Buffer {
 
     pub fn as_slice(&self) -> &[u8] {
         self.inner.as_slice()
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.inner.as_mut_slice()
     }
 
     pub fn into_inner(mut self) -> Vec<u8> {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,13 +1,13 @@
 //! Secure buffer implementation
 
-use zeroize::Zeroize;
 use std::fmt::{Debug, Error, Formatter};
 use std::mem;
 
 /// Secure buffer implementation.
 ///
-/// On creation, the buffer is initialized with zeroes and on destruction,
-/// its content is **always** set to `0` before being released.
+/// On creation, the buffer is initialized with zeroes.
+/// On destruction, if the `zeroize` feature is enabled, its content is set to
+/// `0` before being released.
 #[derive(PartialOrd, PartialEq)]
 pub struct Buffer {
     inner: Vec<u8>,
@@ -72,7 +72,8 @@ impl Buffer {
 
 impl Drop for Buffer {
     fn drop(&mut self) {
-        self.inner.zeroize();
+        #[cfg(feature = "zeroize")]
+        zeroize::Zeroize::zeroize(&mut self.inner);
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,6 +2,7 @@
 
 use zeroize::Zeroize;
 use std::fmt::{Debug, Error, Formatter};
+use std::mem;
 
 /// Secure buffer implementation.
 ///
@@ -54,6 +55,10 @@ impl Buffer {
 
     pub fn as_slice(&self) -> &[u8] {
         self.inner.as_slice()
+    }
+
+    pub fn into_inner(mut self) -> Vec<u8> {
+        mem::replace(&mut self.inner, Vec::new())
     }
 }
 


### PR DESCRIPTION
Continue to provide safe buffer implementation by default but allow to opt-out of the `zeroize` dependency. Also bumps `zeroize` to 1.0.

This is done to support lower-than 1.39 MSRV and to allow the users to manage the security themselves if they want to (e.g. other crates might be used or the overhead of always zeroing every buffer might be too much)