### PR TITLE
Implement standard Error trait for crate Error type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl Error {
-    fn check(status: NTSTATUS) -> std::result::Result<(), Self> {
+    fn check(status: NTSTATUS) -> Result<()> {
         match status {
             ntstatus::STATUS_SUCCESS => Ok(()),
             ntstatus::STATUS_NOT_FOUND => Err(Error::NotFound),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ use doc_comment::doctest;
 use winapi::shared::ntdef::NTSTATUS;
 use winapi::shared::ntstatus;
 
+use std::fmt;
+
 pub mod buffer;
 pub mod hash;
 pub mod random;
@@ -29,6 +31,14 @@ pub enum Error {
 
     Unknown(NTSTATUS),
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {}
 
 impl Error {
     fn check(status: NTSTATUS) -> std::result::Result<(), Self> {


### PR DESCRIPTION
...so that we can use the `?` error propagation.