### PR TITLE
Fix a typo in README.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Émile Grégoire. All rights reserved.
+Copyright (c) 2019-2020 Émile Grégoire. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Windows, you already accepted to trust these primitives.
   - Supported algorithms: AES, DES, DES-X, RC2, 3DES, 3DES-112.
   - Supported chaining modes: ECB, CBC, CFB.
 - Hash functions
-  - Supported algorithms: SHA-1, SHA-256, SHA-384, SHA-512, SHA-512, MD2, MD4, MD5.
+  - Supported algorithms: SHA-1, SHA-256, SHA-384, SHA-512, MD2, MD4, MD5.
 - Cryptographically secure random number generation
 
 *More to come*


### PR DESCRIPTION
Removes a duplicated SHA-512 algorithm from supported algorithm list.