### PR TITLE
Lower MSRV to 1.34

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.37.0  # MSRV
+          - 1.34.0  # MSRV (latest Debian stable)
           - stable
           - beta
           - nightly
@@ -14,7 +14,7 @@ jobs:
           - ""
           - "zeroize"
         exclude: # Zeroize 1.1 supports Rust 1.39+
-          - rust: 1.37.0
+          - rust: 1.34.0
             features: "zeroize"
     steps:
     - uses: actions/checkout@v1

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -99,15 +99,15 @@ pub enum HashAlgorithmId {
 impl HashAlgorithmId {
     fn to_str(&self) -> &str {
         match self {
-            Self::Sha1 => BCRYPT_SHA1_ALGORITHM,
-            Self::Sha256 => BCRYPT_SHA256_ALGORITHM,
-            Self::Sha384 => BCRYPT_SHA384_ALGORITHM,
-            Self::Sha512 => BCRYPT_SHA512_ALGORITHM,
-            Self::Md2 => BCRYPT_MD2_ALGORITHM,
-            Self::Md4 => BCRYPT_MD4_ALGORITHM,
-            Self::Md5 => BCRYPT_MD5_ALGORITHM,
-            //Self::AesCmac => BCRYPT_AES_CMAC_ALGORITHM,
-            //Self::AesGmac => BCRYPT_AES_GMAC_ALGORITHM,
+            HashAlgorithmId::Sha1 => BCRYPT_SHA1_ALGORITHM,
+            HashAlgorithmId::Sha256 => BCRYPT_SHA256_ALGORITHM,
+            HashAlgorithmId::Sha384 => BCRYPT_SHA384_ALGORITHM,
+            HashAlgorithmId::Sha512 => BCRYPT_SHA512_ALGORITHM,
+            HashAlgorithmId::Md2 => BCRYPT_MD2_ALGORITHM,
+            HashAlgorithmId::Md4 => BCRYPT_MD4_ALGORITHM,
+            HashAlgorithmId::Md5 => BCRYPT_MD5_ALGORITHM,
+            //HashAlgorithmId::AesCmac => BCRYPT_AES_CMAC_ALGORITHM,
+            //HashAlgorithmId::AesGmac => BCRYPT_AES_GMAC_ALGORITHM,
         }
     }
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -196,20 +196,20 @@ enum RandomAlgoHandle {
 
 impl RandomAlgoHandle {
     fn open(id: RandomAlgorithmId) -> crate::Result<Self> {
-        Ok(Self::Specified(AlgoHandle::open(id.into())?))
+        Ok(RandomAlgoHandle::Specified(AlgoHandle::open(id.into())?))
     }
 
     fn handle(&self) -> BCRYPT_ALG_HANDLE {
         match self {
-            Self::SystemPreferred => ptr::null_mut(),
-            Self::Specified(handle) => handle.as_ptr(),
+            RandomAlgoHandle::SystemPreferred => ptr::null_mut(),
+            RandomAlgoHandle::Specified(handle) => handle.as_ptr(),
         }
     }
 
     fn flags(&self) -> ULONG {
         match self {
-            Self::SystemPreferred => BCRYPT_USE_SYSTEM_PREFERRED_RNG,
-            Self::Specified(_) => 0,
+            RandomAlgoHandle::SystemPreferred => BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+            RandomAlgoHandle::Specified(_) => 0,
         }
     }
 }

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -93,13 +93,13 @@ impl SymmetricAlgorithmId {
     fn to_str(&self) -> &str {
         match self {
             Self::Aes => BCRYPT_AES_ALGORITHM,
-            Self::Des => BCRYPT_DES_ALGORITHM,
-            Self::DesX => BCRYPT_DESX_ALGORITHM,
-            Self::Rc2 => BCRYPT_RC2_ALGORITHM,
-            //Self::Rc4 => BCRYPT_RC4_ALGORITHM,
-            Self::TripleDes => BCRYPT_3DES_ALGORITHM,
-            Self::TripleDes112 => BCRYPT_3DES_112_ALGORITHM,
-            //Self::XtsAes => BCRYPT_XTS_AES_ALGORITHM,
+            SymmetricAlgorithmId::Des => BCRYPT_DES_ALGORITHM,
+            SymmetricAlgorithmId::DesX => BCRYPT_DESX_ALGORITHM,
+            SymmetricAlgorithmId::Rc2 => BCRYPT_RC2_ALGORITHM,
+            //SymmetricAlgorithmId::Rc4 => BCRYPT_RC4_ALGORITHM,
+            SymmetricAlgorithmId::TripleDes => BCRYPT_3DES_ALGORITHM,
+            SymmetricAlgorithmId::TripleDes112 => BCRYPT_3DES_112_ALGORITHM,
+            //SymmetricAlgorithmId::XtsAes => BCRYPT_XTS_AES_ALGORITHM,
         }
     }
 }
@@ -136,11 +136,11 @@ pub enum ChainingMode {
 impl ChainingMode {
     fn to_str(&self) -> &str {
         match self {
-            Self::Ecb => BCRYPT_CHAIN_MODE_ECB,
-            Self::Cbc => BCRYPT_CHAIN_MODE_CBC,
-            Self::Cfb => BCRYPT_CHAIN_MODE_CFB,
-            //Self::Ccm => BCRYPT_CHAIN_MODE_CCM,
-            //Self::Gcm => BCRYPT_CHAIN_MODE_GCM,
+            ChainingMode::Ecb => BCRYPT_CHAIN_MODE_ECB,
+            ChainingMode::Cbc => BCRYPT_CHAIN_MODE_CBC,
+            ChainingMode::Cfb => BCRYPT_CHAIN_MODE_CFB,
+            //ChainingMode::Ccm => BCRYPT_CHAIN_MODE_CCM,
+            //ChainingMode::Gcm => BCRYPT_CHAIN_MODE_GCM,
         }
     }
 }

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -352,8 +352,8 @@ impl SymmetricAlgorithmKey {
     ///     0xB4, 0x4A, 0xB8, 0xA0, 0xEA, 0x0E, 0x8F, 0x31]);
     /// ```
     pub fn encrypt(&self, iv: Option<&[u8]>, data: &[u8]) -> Result<Buffer> {
-        let mut iv_copy = iv.map(|iv| Buffer::from(iv));
-        let iv_ptr = iv_copy.as_mut().map_or(null_mut(), |iv| iv.as_mut_ptr());
+        let mut iv_copy = iv.map(Buffer::from);
+        let iv_ptr = iv_copy.as_mut().map_or(null_mut(), Buffer::as_mut_ptr);
         let iv_len = iv_copy.as_ref().map_or(0, |iv| iv.len() as ULONG);
 
         let mut encrypted_len = MaybeUninit::<ULONG>::uninit();
@@ -415,8 +415,8 @@ impl SymmetricAlgorithmKey {
     /// assert_eq!(&plaintext.as_slice()[..16], "THIS_IS_THE_DATA".as_bytes());
     /// ```
     pub fn decrypt(&self, iv: Option<&[u8]>, data: &[u8]) -> Result<Buffer> {
-        let mut iv_copy = iv.map(|iv| Buffer::from(iv));
-        let iv_ptr = iv_copy.as_mut().map_or(null_mut(), |iv| iv.as_mut_ptr());
+        let mut iv_copy = iv.map(Buffer::from);
+        let iv_ptr = iv_copy.as_mut().map_or(null_mut(), Buffer::as_mut_ptr);
         let iv_len = iv_copy.as_ref().map_or(0, |iv| iv.len() as ULONG);
 
         let mut plaintext_len = MaybeUninit::<ULONG>::uninit();


### PR DESCRIPTION
In principle, I agree that 1.36-37 is a reasonable MSRV but we'd like to use it in Sequoia which targets Debian stable (1.34 for now). cc @teythoon

Changes:
* Enum variants are explicitly typed (not using `Self` type alias)
* `ULONG`s initialized by FFI are always first initialized to 0 (doesn't use `MaybeUninit`)
* Zero-initializes the returned value that's then initialized by FFI (doesn't use `MaybeUninit`)

The biggest downside is having to rely on a custom `ZeroInitSafe` trait and impls to safely initialize structs on Rust before passing them to FFI but the cost should be fairly negligible.