### PR TITLE
Allow for dynamically fetching hash algorithm for hasher objects

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -45,9 +45,10 @@
 //! [`finish`]: struct.Hash.html#method.finish
 
 use crate::buffer::Buffer;
-use crate::helpers::{AlgoHandle, Handle};
-use crate::property::{HashLength, ObjectLength};
+use crate::helpers::{AlgoHandle, Handle, WindowsString};
+use crate::property::{AlgorithmName, HashLength, ObjectLength};
 use crate::{Error, Result};
+use std::convert::TryFrom;
 use std::ptr::null_mut;
 use winapi::shared::bcrypt::*;
 use winapi::shared::minwindef::{PUCHAR, ULONG};
@@ -109,6 +110,23 @@ impl HashAlgorithmId {
             Self::Md5 => BCRYPT_MD5_ALGORITHM,
             //Self::AesCmac => BCRYPT_AES_CMAC_ALGORITHM,
             //Self::AesGmac => BCRYPT_AES_GMAC_ALGORITHM,
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for HashAlgorithmId {
+    type Error = &'a str;
+
+    fn try_from(val: &'a str) -> std::result::Result<HashAlgorithmId, Self::Error> {
+        match val {
+            BCRYPT_SHA1_ALGORITHM => Ok(Self::Sha1),
+            BCRYPT_SHA256_ALGORITHM => Ok(Self::Sha256),
+            BCRYPT_SHA384_ALGORITHM => Ok(Self::Sha384),
+            BCRYPT_SHA512_ALGORITHM => Ok(Self::Sha512),
+            BCRYPT_MD2_ALGORITHM => Ok(Self::Md2),
+            BCRYPT_MD4_ALGORITHM => Ok(Self::Md4),
+            BCRYPT_MD5_ALGORITHM => Ok(Self::Md5),
+            val => Err(val),
         }
     }
 }
@@ -274,6 +292,27 @@ impl Hash {
         self.handle
             .get_property::<HashLength>()
             .map(|hash_size| hash_size.copied() as usize)
+    }
+
+    /// Get the hash algorithm used for this hash object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use win_crypto_ng::hash::{HashAlgorithm, HashAlgorithmId};
+    /// let algo = HashAlgorithm::open(HashAlgorithmId::Sha256).unwrap();
+    /// let hash = algo.new_hash().unwrap();
+    ///
+    /// assert_eq!(hash.hash_algorithm().unwrap(), HashAlgorithmId::Sha256);
+    /// ```
+    pub fn hash_algorithm(&self) -> Result<HashAlgorithmId> {
+        self.handle
+            .get_property_unsized::<AlgorithmName>()
+            .map(|name| WindowsString::from_ptr(name.as_ref().as_ptr()).to_string())
+            .map(|name| {
+                HashAlgorithmId::try_from(name.as_str())
+                    .expect("Windows CNG API to return a correct algorithm name")
+            })
     }
 }
 

--- a/src/property.rs
+++ b/src/property.rs
@@ -10,6 +10,17 @@ pub trait Property {
     type Value: ?Sized;
 }
 
+/// [**BCRYPT_ALGORITHM_NAME**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_ALGORITHM_NAME)
+///
+/// `L"AlgorithmName"`
+///
+/// A null-terminated Unicode string that contains the name of the algorithm.
+pub enum AlgorithmName {}
+impl Property for AlgorithmName {
+    const IDENTIFIER: &'static str = bcrypt::BCRYPT_ALGORITHM_NAME;
+    type Value = [WCHAR];
+}
+
 /// [**BCRYPT_BLOCK_LENGTH**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_BLOCK_LENGTH)
 ///
 /// `L"BlockLength"`


### PR DESCRIPTION
This is useful:
1) to dynamically inspect the hash used or
2) to create fresh hasher instances based on a concrete hasher value.