### PR TITLE
Add support for getting unsized CNG properties and make the property API more ergonomic

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -46,10 +46,11 @@
 
 use crate::buffer::Buffer;
 use crate::helpers::{AlgoHandle, Handle};
+use crate::property::{HashLength, ObjectLength};
 use crate::{Error, Result};
 use std::ptr::null_mut;
 use winapi::shared::bcrypt::*;
-use winapi::shared::minwindef::{DWORD, PUCHAR, ULONG};
+use winapi::shared::minwindef::{PUCHAR, ULONG};
 
 /// Hashing algorithm identifiers
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq)]
@@ -136,10 +137,10 @@ impl HashAlgorithm {
 
     /// Creates a new hash from the algorithm
     pub fn new_hash(&self) -> Result<Hash> {
-        let object_size = self.handle.get_property::<DWORD>(BCRYPT_OBJECT_LENGTH)? as usize;
+        let object_size = self.handle.get_property::<ObjectLength>()?.copied();
 
         let mut hash_handle = HashHandle::new();
-        let mut object = Buffer::new(object_size);
+        let mut object = Buffer::new(object_size as usize);
         unsafe {
             Error::check(BCryptCreateHash(
                 self.handle.as_ptr(),
@@ -271,8 +272,8 @@ impl Hash {
     /// ```
     pub fn hash_size(&self) -> Result<usize> {
         self.handle
-            .get_property::<DWORD>(BCRYPT_HASH_LENGTH)
-            .map(|hash_size| hash_size as usize)
+            .get_property::<HashLength>()
+            .map(|hash_size| hash_size.copied() as usize)
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,6 @@
 use crate::{Error, Result};
 use std::ffi::{OsStr, OsString};
+use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::ptr::{null, null_mut};
@@ -140,3 +141,146 @@ impl ToString for WindowsString {
         }
     }
 }*/
+
+/// A typed view into an opaque blob of heap-allocated bytes.
+pub struct TypedBlob<T: ?Sized> {
+    allocation: Box<[u8]>,
+    marker: PhantomData<T>,
+}
+
+impl<T: ?Sized> Into<Box<[u8]>> for TypedBlob<T> {
+    fn into(self) -> Box<[u8]> {
+        self.allocation
+    }
+}
+
+#[allow(dead_code)]
+impl<T: ?Sized> TypedBlob<T> {
+    pub fn into_inner(self) -> Box<[u8]> {
+        self.into()
+    }
+}
+
+impl<T: Sized> AsRef<T> for TypedBlob<T> {
+    /// Creates a typed reference to the underlying data structure backed by the
+    /// source bytes.
+    fn as_ref(&self) -> &T {
+        // SAFETY: The only way to create this struct with sized `T` is via
+        // `TypedBlob::from_box`, where:
+        // 1. the caller has to prove that the data is of correct format,
+        // 2. we check that the resulting reference will be well-aligned, and
+        // 3. the allocation is big enough to hold a value of type `T`.
+        unsafe { &*(self.allocation.as_ptr() as *const T) }
+    }
+}
+
+#[allow(dead_code)]
+impl<T: Sized> TypedBlob<T> {
+    /// Converts an opaque blob of bytes into a typed blob asserting that the
+    /// raw bytes correspond in shape to value of type `T`.
+    ///
+    /// # Panics
+    /// This function panicks if the allocation is not big enough to hold a
+    /// value of type `T` or if the backing pointee alignment is not compatible
+    /// with that of `T`.
+    pub unsafe fn from_box(allocation: Box<[u8]>) -> Self {
+        assert!(allocation.len() >= std::mem::size_of::<T>());
+        // Verify that we can produce a valid reference (which are required to
+        // always be well-aligned).
+        assert_eq!(allocation.as_ptr() as usize % std::mem::align_of::<T>(), 0);
+
+        TypedBlob {
+            allocation,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T> AsRef<[T]> for TypedBlob<[T]> {
+    /// Creates a typed reference to the underlying data structure backed by the
+    /// source bytes.
+    ///
+    /// # Panics
+    /// This function panicks if the allocation does not fit exactly a certain
+    /// count of `T`-sized values.
+    fn as_ref(&self) -> &[T] {
+        // SAFETY: The only way to create this struct with *unsized* `T` is via
+        // `TypedBlob::from_box_unsized`, where:
+        // 1. the caller has to prove that the data is of correct format,
+        // 2. we check that the resulting reference will be well-aligned.
+
+        // Ensure that allocation can hold exactly N elements of type T - we
+        // disallow any trailing bytes outside of the resulting `[T]` slice.
+        assert_eq!(self.allocation.len() % std::mem::size_of::<T>(), 0);
+
+        unsafe {
+            std::slice::from_raw_parts(
+                self.allocation.as_ptr() as *const T,
+                // Account for possibly fewer slice elements, e.g. [u16] will
+                // have 2 times fewer elements than [u8] for the same bytes.
+                self.allocation.len() * std::mem::size_of::<u8>() / std::mem::size_of::<T>(),
+            )
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl<T: ?Sized> TypedBlob<T> {
+    /// Converts an opaque blob of bytes into a typed blob asserting that the
+    /// raw bytes correspond in shape to value of type `T`.
+    ///
+    /// # Panics
+    /// This function panicks if the backing pointee alignment is not compatible
+    /// with that of `&T`.
+    ///
+    /// # Safety
+    /// The caller has to guarantee that the type of is of correct layout.
+    /// For slices (`[T]`), the memory allocation should contain *exactly* given
+    /// N elements of type T.
+    pub unsafe fn from_box_unsized(allocation: Box<[u8]>) -> Self {
+        // Verify that we can produce a valid reference (which are required to
+        // always be well-aligned).
+        assert_eq!(
+            allocation.as_ptr() as usize % std::mem::align_of::<&T>(),
+            0
+        );
+
+        TypedBlob {
+            allocation,
+            marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_blob() {
+        #[repr(C)]
+        #[derive(Debug)]
+        struct Inner {
+            first: u16,
+            second: u32,
+        }
+
+        let bytes = vec![0x1, 0x1, 0xFF, 0xFF, 0x2, 0x2, 0x2, 0x2, 0xDE, 0xDE].into_boxed_slice();
+        let typed = unsafe { TypedBlob::<Inner>::from_box(bytes.clone()) };
+        assert_eq!(typed.as_ref().first, 0x0101);
+        assert_eq!(typed.as_ref().second, 0x02020202);
+        let typed = unsafe { TypedBlob::<[u8; 10]>::from_box(bytes.clone()) };
+        assert_eq!(typed.as_ref(), bytes.as_ref());
+
+        let typed = unsafe { TypedBlob::<[u8]>::from_box_unsized(bytes.clone()) };
+        assert_eq!(typed.as_ref(), bytes.as_ref());
+        let typed = unsafe { TypedBlob::<[u16]>::from_box_unsized(bytes.clone()) };
+        assert_eq!(typed.as_ref(), &[0x0101, 0xFFFF, 0x0202, 0x0202, 0xDEDE]);
+
+        assert!(std::panic::catch_unwind(|| {
+            // Allocation is too small
+            unsafe { TypedBlob::<[[u8; 1000]; 1]>::from_box(bytes.clone()) }
+        })
+        .is_err());
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -86,9 +86,6 @@ pub trait Handle {
                 0,
             ))?;
         }
-        // Assert that we actually wrote as many bytes as we were asked to
-        // allocate
-        assert_eq!(result.len(), size as usize);
 
         Ok(unsafe { TypedBlob::from_box_unsized(result) })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 pub mod buffer;
 pub mod hash;
+pub mod property;
 pub mod random;
 pub mod symmetric;
 

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,0 +1,102 @@
+//! Named properties support for CNG objects.
+
+use winapi::shared::bcrypt;
+use winapi::shared::minwindef::DWORD;
+use winapi::shared::ntdef::WCHAR;
+
+// Marker trait for any type that can be used as the CNG property.
+pub trait Property {
+    const IDENTIFIER: &'static str;
+    type Value: ?Sized;
+}
+
+/// [**BCRYPT_BLOCK_LENGTH**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_BLOCK_LENGTH)
+///
+/// `L"BlockLength"`
+///
+/// The size, in bytes, of a cipher block for the algorithm. This property only
+/// applies to block cipher algorithms. This data type is a **DWORD**.
+pub enum BlockLength {}
+impl Property for BlockLength {
+    const IDENTIFIER: &'static str = bcrypt::BCRYPT_BLOCK_LENGTH;
+    type Value = DWORD;
+}
+
+/// [**BCRYPT_CHAINING_MODE**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_CHAINING_MODE)
+///
+/// `L"ChainingMode"`
+///
+/// A pointer to a null-terminated Unicode string that represents the chaining
+/// mode of the encryption algorithm. This property can be set on an algorithm
+/// handle or a key handle to one of the following values.
+///
+/// | Identifier            | Value              |  Description                                                                                                                                         |
+/// |-----------------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+/// | BCRYPT_CHAIN_MODE_CBC | L"ChainingModeCBC" | Sets the algorithm's chaining mode to cipher block chaining.                                                                                         |
+/// | BCRYPT_CHAIN_MODE_CCM | L"ChainingModeCCM" | Sets the algorithm's chaining mode to counter with CBC-MAC mode (CCM).Windows Vista:  This value is supported beginning with Windows Vista with SP1. |
+/// | BCRYPT_CHAIN_MODE_CFB | L"ChainingModeCFB" | Sets the algorithm's chaining mode to cipher feedback.                                                                                               |
+/// | BCRYPT_CHAIN_MODE_ECB | L"ChainingModeECB" | Sets the algorithm's chaining mode to electronic codebook.                                                                                           |
+/// | BCRYPT_CHAIN_MODE_GCM | L"ChainingModeGCM" | Sets the algorithm's chaining mode to Galois/counter mode (GCM).Windows Vista:  This value is supported beginning with Windows Vista with SP1.       |
+/// | BCRYPT_CHAIN_MODE_NA  | L"ChainingModeN/A" | The algorithm does not support chaining.                                                                                                             |
+pub enum ChainingMode {}
+impl Property for ChainingMode {
+    const IDENTIFIER: &'static str = bcrypt::BCRYPT_CHAINING_MODE;
+    type Value = [WCHAR];
+}
+
+/// [**BCRYPT_HASH_LENGTH**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_HASH_LENGTH)
+///
+/// `L"HashDigestLength"`
+///
+/// The size, in bytes, of the hash value of a hash provider. This data type is
+/// a **DWORD**.
+pub enum HashLength {}
+impl Property for HashLength {
+    const IDENTIFIER: &'static str = bcrypt::BCRYPT_HASH_LENGTH;
+    type Value = DWORD;
+}
+
+/// [**BCRYPT_KEY_LENGTH**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_KEY_LENGTH)
+///
+/// `L"KeyLength"`
+///
+/// The size, in bits, of the key value of a symmetric key provider. This data
+/// type is a **DWORD**.
+pub enum KeyLength {}
+impl Property for KeyLength {
+    const IDENTIFIER: &'static str = bcrypt::BCRYPT_KEY_LENGTH;
+    type Value = DWORD;
+}
+
+/// [**BCRYPT_KEY_LENGTHS**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_KEY_LENGTHS)
+///
+/// `L"KeyLengths"`
+///
+/// The key lengths that are supported by the algorithm. This property is a
+/// [BCRYPT_KEY_LENGTHS_STRUCT] structure. This property only applies to
+/// algorithms.
+///
+/// [BCRYPT_KEY_LENGTHS_STRUCT]: https://docs.microsoft.com/windows/desktop/api/Bcrypt/ns-bcrypt-bcrypt_key_lengths_struct
+pub enum KeyLengths {}
+impl Property for KeyLengths {
+    const IDENTIFIER: &'static str = bcrypt::BCRYPT_KEY_LENGTHS;
+    type Value = bcrypt::BCRYPT_KEY_LENGTHS_STRUCT;
+}
+
+/// [**BCRYPT_OBJECT_LENGTH**](https://docs.microsoft.com/windows/win32/seccng/cng-property-identifiers#BCRYPT_OBJECT_LENGTH)
+///
+/// `L"ObjectLength"`
+///
+/// The size, in bytes, of the subobject of a provider. This data type is a
+/// **DWORD**. Currently, the hash and symmetric cipher algorithm providers use
+/// caller-allocated buffers to store their subobjects. For example, the hash
+/// provider requires you to allocate memory for the hash object obtained with
+/// the [BCryptCreateHash] function. This property provides the buffer size for a
+/// provider's object so you can allocate memory for the object created by the
+/// provider.
+/// [BCryptCreateHash]: https://docs.microsoft.com/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash
+pub enum ObjectLength {}
+impl Property for ObjectLength {
+    const IDENTIFIER: &'static str = bcrypt::BCRYPT_OBJECT_LENGTH;
+    type Value = DWORD;
+}


### PR DESCRIPTION
This PR enables us to fetch dynamically-sized properties such as strings or structs with VLAs/trailing bytes and introduces a safe way to inspect such data in a type-safe way via new `TypedBlob` struct.

This unblocks further work on ergonomically handling structs like [`BCRYPT_RSAKEY_BLOB`](https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_rsakey_blob`) or fetching string properties like `BCRYPT_ALGORITHM_NAME`.