### PR TITLE
Tweak to_str methods

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -97,7 +97,7 @@ pub enum HashAlgorithmId {
 }
 
 impl HashAlgorithmId {
-    fn to_str(&self) -> &str {
+    fn to_str(&self) -> &'static str {
         match self {
             Self::Sha1 => BCRYPT_SHA1_ALGORITHM,
             Self::Sha256 => BCRYPT_SHA256_ALGORITHM,

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -97,7 +97,7 @@ pub enum HashAlgorithmId {
 }
 
 impl HashAlgorithmId {
-    fn to_str(&self) -> &'static str {
+    fn to_str(self) -> &'static str {
         match self {
             Self::Sha1 => BCRYPT_SHA1_ALGORITHM,
             Self::Sha256 => BCRYPT_SHA256_ALGORITHM,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -112,8 +112,10 @@ impl WindowsString {
     pub fn as_ptr(&self) -> LPCWSTR {
         self.inner.as_ptr()
     }
+}
 
-    pub fn to_str(&self) -> String {
+impl ToString for WindowsString {
+    fn to_string(&self) -> String {
         OsString::from_wide(&self.inner)
             .to_string_lossy()
             .as_ref()

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -90,7 +90,7 @@ pub enum SymmetricAlgorithmId {
 }
 
 impl SymmetricAlgorithmId {
-    fn to_str(&self) -> &str {
+    fn to_str(&self) -> &'static str {
         match self {
             Self::Aes => BCRYPT_AES_ALGORITHM,
             Self::Des => BCRYPT_DES_ALGORITHM,
@@ -134,7 +134,7 @@ pub enum ChainingMode {
 }
 
 impl ChainingMode {
-    fn to_str(&self) -> &str {
+    fn to_str(&self) -> &'static str {
         match self {
             Self::Ecb => BCRYPT_CHAIN_MODE_ECB,
             Self::Cbc => BCRYPT_CHAIN_MODE_CBC,

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -90,7 +90,7 @@ pub enum SymmetricAlgorithmId {
 }
 
 impl SymmetricAlgorithmId {
-    fn to_str(&self) -> &'static str {
+    fn to_str(self) -> &'static str {
         match self {
             Self::Aes => BCRYPT_AES_ALGORITHM,
             Self::Des => BCRYPT_DES_ALGORITHM,
@@ -134,7 +134,7 @@ pub enum ChainingMode {
 }
 
 impl ChainingMode {
-    fn to_str(&self) -> &'static str {
+    fn to_str(self) -> &'static str {
         match self {
             Self::Ecb => BCRYPT_CHAIN_MODE_ECB,
             Self::Cbc => BCRYPT_CHAIN_MODE_CBC,


### PR DESCRIPTION
Mainly return a `&'static str` for well-known constants.