### PR TITLE
Use sized variant of TypedBlob when property is bigger than its sizeof

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -66,7 +66,7 @@ pub trait Handle {
             // allocate
             assert_eq!(result.len(), size as usize);
 
-            MaybeUnsized::Unsized(unsafe { TypedBlob::from_box_unsized(result) })
+            MaybeUnsized::Unsized(unsafe { TypedBlob::from_box(result) })
         })
     }
 


### PR DESCRIPTION
We should be using the sized variant here - we need to see if the
allocation is big enough to hold a structure of that size. The sizes of
the allocation and the concrete T type may be different if we're dealing
with a 'header type with more data following' kind of struct, as is
often the case in the CNG API.