### PR TITLE
Typed blob improvements

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -216,6 +216,10 @@ impl<T: ?Sized> TypedBlob<T> {
     pub fn into_inner(self) -> Box<[u8]> {
         self.into()
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.allocation
+    }
 }
 
 impl<T: Sized> AsRef<T> for TypedBlob<T> {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -299,6 +299,10 @@ impl<T: ?Sized> TypedBlob<T> {
     /// Converts an opaque blob of bytes into a typed blob asserting that the
     /// raw bytes correspond in shape to value of type `T`.
     ///
+    /// **NOTE: Only slices are supported at the moment.** To uphold safety
+    /// invariants, this type can only be safely dereferenced for slice types,
+    /// as long as the allocation size matches the slice layout.
+    ///
     /// # Panics
     /// This function panicks if the backing pointee alignment is not compatible
     /// with that of `&T`.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -238,9 +238,9 @@ impl<T: Sized> Deref for TypedBlob<T> {
     }
 }
 
-impl<T: Sized> AsRef<T> for TypedBlob<T> {
+impl<T, U: AsRef<T>> AsRef<T> for TypedBlob<U> {
     fn as_ref(&self) -> &T {
-        self
+        self.deref().as_ref()
     }
 }
 
@@ -337,7 +337,7 @@ impl<T> AsRef<T> for MaybeUnsized<T> {
     fn as_ref(&self) -> &T {
         match self {
             Self::Inline(value) => &value,
-            Self::Unsized(blob) => blob.as_ref(),
+            Self::Unsized(blob) => &blob,
         }
     }
 }
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(typed.first, 0x0101);
         assert_eq!(typed.second, 0x02020202);
         let typed = unsafe { TypedBlob::<[u8; 10]>::from_box(bytes.clone()) };
-        assert_eq!(typed.as_ref(), bytes.as_ref());
+        assert_eq!(&*typed, bytes.as_ref());
 
         let typed = unsafe { TypedBlob::<[u8]>::from_box_unsized(bytes.clone()) };
         assert_eq!(typed.as_ref(), bytes.as_ref());


### PR DESCRIPTION
Few improvements here and there, each commit provides a reason on why we're introducing a relevant change. Most importantly this lays groundwork for dynamically interpreted structs such as key blobs in the CNG API.