### PR TITLE
Introduce a dedicated error module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,9 +34,15 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-impl Error {
-    pub fn check(status: NTSTATUS) -> Result<()> {
-        match status {
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub(crate) trait IntoResult {
+    fn into_result(self) -> Result<()>;
+}
+
+impl IntoResult for NTSTATUS {
+    fn into_result(self) -> Result<()> {
+        match self {
             ntstatus::STATUS_SUCCESS => Ok(()),
             ntstatus::STATUS_NOT_FOUND => Err(Error::NotFound),
             ntstatus::STATUS_INVALID_PARAMETER => Err(Error::InvalidParameter),
@@ -50,5 +56,3 @@ impl Error {
         }
     }
 }
-
-pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,54 @@
+//! Error types
+//!
+//! Error types used by this library. Encapsulates the errors returned by the
+//! Windows CNG API.
+
+use winapi::shared::ntdef::NTSTATUS;
+use winapi::shared::ntstatus;
+
+use std::fmt;
+
+/// Error type
+///
+/// These errors are a subset of [`NTSTATUS`](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55).
+/// Only the values used by CNG are part of this enum.
+#[derive(Clone, Copy, Debug, PartialOrd, PartialEq)]
+pub enum Error {
+    NotFound,
+    InvalidParameter,
+    NoMemory,
+    BufferTooSmall,
+    InvalidHandle,
+    NotSupported,
+    AuthTagMismatch,
+    InvalidBufferSize,
+
+    Unknown(NTSTATUS),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Error {
+    pub fn check(status: NTSTATUS) -> Result<()> {
+        match status {
+            ntstatus::STATUS_SUCCESS => Ok(()),
+            ntstatus::STATUS_NOT_FOUND => Err(Error::NotFound),
+            ntstatus::STATUS_INVALID_PARAMETER => Err(Error::InvalidParameter),
+            ntstatus::STATUS_NO_MEMORY => Err(Error::NoMemory),
+            ntstatus::STATUS_BUFFER_TOO_SMALL => Err(Error::BufferTooSmall),
+            ntstatus::STATUS_INVALID_HANDLE => Err(Error::InvalidHandle),
+            ntstatus::STATUS_NOT_SUPPORTED => Err(Error::NotSupported),
+            ntstatus::STATUS_AUTH_TAG_MISMATCH => Err(Error::AuthTagMismatch),
+            ntstatus::STATUS_INVALID_BUFFER_SIZE => Err(Error::InvalidBufferSize),
+            value => Err(Error::Unknown(value)),
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ use doc_comment::doctest;
 
 pub mod buffer;
 pub mod error;
-pub use error::{Error, Result};
 pub mod hash;
 pub mod property;
 pub mod random;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 use doc_comment::doctest;
-use winapi::shared::ntdef::NTSTATUS;
-use winapi::shared::ntstatus;
-
-use std::fmt;
 
 pub mod buffer;
+pub mod error;
+pub use error::{Error, Result};
 pub mod hash;
 pub mod property;
 pub mod random;
@@ -14,48 +12,3 @@ mod helpers;
 
 // Compile and test the README
 doctest!("../README.md");
-
-/// Error type
-///
-/// These errors are a subset of [`NTSTATUS`](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55).
-/// Only the values used by CNG are part of this enum.
-#[derive(Clone, Copy, Debug, PartialOrd, PartialEq)]
-pub enum Error {
-    NotFound,
-    InvalidParameter,
-    NoMemory,
-    BufferTooSmall,
-    InvalidHandle,
-    NotSupported,
-    AuthTagMismatch,
-    InvalidBufferSize,
-
-    Unknown(NTSTATUS),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl Error {
-    fn check(status: NTSTATUS) -> Result<()> {
-        match status {
-            ntstatus::STATUS_SUCCESS => Ok(()),
-            ntstatus::STATUS_NOT_FOUND => Err(Error::NotFound),
-            ntstatus::STATUS_INVALID_PARAMETER => Err(Error::InvalidParameter),
-            ntstatus::STATUS_NO_MEMORY => Err(Error::NoMemory),
-            ntstatus::STATUS_BUFFER_TOO_SMALL => Err(Error::BufferTooSmall),
-            ntstatus::STATUS_INVALID_HANDLE => Err(Error::InvalidHandle),
-            ntstatus::STATUS_NOT_SUPPORTED => Err(Error::NotSupported),
-            ntstatus::STATUS_AUTH_TAG_MISMATCH => Err(Error::AuthTagMismatch),
-            ntstatus::STATUS_INVALID_BUFFER_SIZE => Err(Error::InvalidBufferSize),
-            value => Err(Error::Unknown(value)),
-        }
-    }
-}
-
-pub type Result<T> = std::result::Result<T, Error>;

--- a/src/random.rs
+++ b/src/random.rs
@@ -23,8 +23,8 @@
 //! [`system_preferred`]: struct.RandomNumberGenerator.html#method.system_preferred
 //! [`gen_random`]: struct.RandomNumberGenerator.html#method.gen_random
 
+use crate::error::IntoResult;
 use crate::helpers::{AlgoHandle, Handle};
-use crate::Error;
 use core::convert::TryFrom;
 use core::fmt;
 use core::ptr;
@@ -180,9 +180,8 @@ impl RandomNumberGenerator {
     fn gen_random_with_opts(&self, buffer: &mut [u8], opts: ULONG) -> crate::Result<()> {
         let handle = self.handle.handle();
 
-        Error::check(unsafe {
-            BCryptGenRandom(handle, buffer.as_mut_ptr(), buffer.len() as ULONG, opts)
-        })
+        unsafe { BCryptGenRandom(handle, buffer.as_mut_ptr(), buffer.len() as ULONG, opts) }
+            .into_result()
     }
 }
 

--- a/src/random.rs
+++ b/src/random.rs
@@ -23,7 +23,7 @@
 //! [`system_preferred`]: struct.RandomNumberGenerator.html#method.system_preferred
 //! [`gen_random`]: struct.RandomNumberGenerator.html#method.gen_random
 
-use crate::error::IntoResult;
+use crate::error::{IntoResult, Result};
 use crate::helpers::{AlgoHandle, Handle};
 use core::convert::TryFrom;
 use core::fmt;
@@ -76,7 +76,7 @@ pub enum RandomAlgorithmId {
 impl<'a> TryFrom<&'a str> for RandomAlgorithmId {
     type Error = &'a str;
 
-    fn try_from(value: &'a str) -> Result<RandomAlgorithmId, Self::Error> {
+    fn try_from(value: &'a str) -> std::result::Result<RandomAlgorithmId, Self::Error> {
         match value {
             BCRYPT_RNG_ALGORITHM => Ok(RandomAlgorithmId::Rng),
             BCRYPT_RNG_DUAL_EC_ALGORITHM => Ok(RandomAlgorithmId::DualECRng),
@@ -121,7 +121,7 @@ impl RandomNumberGenerator {
     ///
     /// assert!(rng.is_ok());
     /// ```
-    pub fn open(id: RandomAlgorithmId) -> crate::Result<RandomNumberGenerator> {
+    pub fn open(id: RandomAlgorithmId) -> Result<RandomNumberGenerator> {
         let handle = RandomAlgoHandle::open(id)?;
         Ok(Self { handle })
     }
@@ -148,7 +148,7 @@ impl RandomNumberGenerator {
     ///
     /// assert_ne!(&buffer, &[0u8; 32]);
     /// ```
-    pub fn gen_random(&self, buffer: &mut [u8]) -> crate::Result<()> {
+    pub fn gen_random(&self, buffer: &mut [u8]) -> Result<()> {
         self.gen_random_with_opts(buffer, self.handle.flags())
     }
 
@@ -170,14 +170,14 @@ impl RandomNumberGenerator {
     ///
     /// assert_ne!(&buffer, &[0u8; 32]);
     /// ```
-    pub fn gen_random_with_entropy_in_buffer(&self, buffer: &mut [u8]) -> crate::Result<()> {
+    pub fn gen_random_with_entropy_in_buffer(&self, buffer: &mut [u8]) -> Result<()> {
         self.gen_random_with_opts(
             buffer,
             self.handle.flags() | BCRYPT_RNG_USE_ENTROPY_IN_BUFFER,
         )
     }
 
-    fn gen_random_with_opts(&self, buffer: &mut [u8], opts: ULONG) -> crate::Result<()> {
+    fn gen_random_with_opts(&self, buffer: &mut [u8], opts: ULONG) -> Result<()> {
         let handle = self.handle.handle();
 
         unsafe { BCryptGenRandom(handle, buffer.as_mut_ptr(), buffer.len() as ULONG, opts) }
@@ -194,7 +194,7 @@ enum RandomAlgoHandle {
 }
 
 impl RandomAlgoHandle {
-    fn open(id: RandomAlgorithmId) -> crate::Result<Self> {
+    fn open(id: RandomAlgorithmId) -> Result<Self> {
         Ok(Self::Specified(AlgoHandle::open(id.into())?))
     }
 


### PR DESCRIPTION
To bring this more in line with often used dedicated module for library-specific errors as encountered in other crates.

I also added an `IntoResult` trait that converts the numeric error codes returned by the CNG to library-specific `Error` type for ease of chaining and to be slightly more Rust idiomatic when we transform the relevant data.