### PR TITLE
Make local Result type more flexible

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -117,7 +117,7 @@ impl HashAlgorithmId {
 impl<'a> TryFrom<&'a str> for HashAlgorithmId {
     type Error = &'a str;
 
-    fn try_from(val: &'a str) -> std::result::Result<HashAlgorithmId, Self::Error> {
+    fn try_from(val: &'a str) -> Result<HashAlgorithmId, Self::Error> {
         match val {
             BCRYPT_SHA1_ALGORITHM => Ok(Self::Sha1),
             BCRYPT_SHA256_ALGORITHM => Ok(Self::Sha256),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl Error {
-    fn check(status: NTSTATUS) -> Result<()> {
+    fn check(status: NTSTATUS) -> crate::Result<()> {
         match status {
             ntstatus::STATUS_SUCCESS => Ok(()),
             ntstatus::STATUS_NOT_FOUND => Err(Error::NotFound),
@@ -58,4 +58,4 @@ impl Error {
     }
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = crate::Error> = std::result::Result<T, E>;


### PR DESCRIPTION
It's still a `std::result::Result` type but now it is *also* generic
over the error type with default set to the crate `Error` enum.

This allows to use both:
- shorthand form `Result<T>`, which implies using `crate::Error`  type as the error,
- fully specified form `Result<T, E>`, which is identical to the `std::result::Result<T, E>`.