### PR TITLE
Support interop with rand crate for the CNG CSPRNG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         features:
           - ""
           - "zeroize"
+          - "rand"
         exclude: # Zeroize 1.1 supports Rust 1.39+
           - rust: 1.37.0
             features: "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 winapi = { version = "0.3", features = ["bcrypt", "ntstatus"] }
 zeroize = { version = "1.1", optional = true }
+rand_core = { version = "0.5", optional = true }
 doc-comment = "0.3"
 
 [dev-dependencies]
@@ -24,6 +25,7 @@ doc-comment = "0.3"
 
 [features]
 default = ["zeroize"]
+rand = ["rand_core"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use winapi::shared::ntdef::NTSTATUS;
 use winapi::shared::ntstatus;
 
 use std::fmt;
+use std::num::NonZeroU32;
 
 pub mod buffer;
 pub mod hash;
@@ -55,6 +56,24 @@ impl Error {
             ntstatus::STATUS_INVALID_BUFFER_SIZE => Err(Error::InvalidBufferSize),
             value => Err(Error::Unknown(value)),
         }
+    }
+}
+
+impl Into<NonZeroU32> for Error {
+    fn into(self) -> NonZeroU32 {
+        let code: i32 = match self {
+            Error::NotFound => ntstatus::STATUS_NOT_FOUND,
+            Error::InvalidParameter => ntstatus::STATUS_INVALID_PARAMETER,
+            Error::BufferTooSmall => ntstatus::STATUS_BUFFER_TOO_SMALL,
+            Error::InvalidHandle => ntstatus::STATUS_INVALID_HANDLE,
+            Error::NotSupported => ntstatus::STATUS_NOT_SUPPORTED,
+            Error::AuthTagMismatch => ntstatus::STATUS_AUTH_TAG_MISMATCH,
+            Error::InvalidBufferSize => ntstatus::STATUS_INVALID_BUFFER_SIZE,
+            Error::NoMemory => ntstatus::STATUS_NO_MEMORY,
+            Error::Unknown(value) => value,
+        };
+
+        NonZeroU32::new(code.abs() as u32).expect("Error to not be STATUS_SUCCESS")
     }
 }
 

--- a/src/random.rs
+++ b/src/random.rs
@@ -186,6 +186,26 @@ impl RandomNumberGenerator {
     }
 }
 
+#[cfg(feature = "rand-trait")]
+impl rand_core::CryptoRng for RandomNumberGenerator {}
+#[cfg(feature = "rand-trait")]
+impl rand_core::RngCore for RandomNumberGenerator {
+    fn next_u32(&mut self) -> u32 {
+        rand_core::impls::next_u32_via_fill(self)
+    }
+    fn next_u64(&mut self) -> u64 {
+        rand_core::impls::next_u64_via_fill(self)
+    }
+    fn fill_bytes(&mut self, dst: &mut [u8]) {
+        // Panics are allowed in `fill_bytes`
+        self.try_fill_bytes(dst).unwrap()
+    }
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.gen_random(dst)
+            .map_err(|e| From::<core::num::NonZeroU32>::from(e.into()))
+    }
+}
+
 /// Wrapper around `AlgoHandle` that can only specify RNG algorithms.
 enum RandomAlgoHandle {
     /// System-preferred algorithm provider.

--- a/src/random.rs
+++ b/src/random.rs
@@ -188,18 +188,22 @@ impl RandomNumberGenerator {
 
 #[cfg(feature = "rand-trait")]
 impl rand_core::CryptoRng for RandomNumberGenerator {}
+
 #[cfg(feature = "rand-trait")]
 impl rand_core::RngCore for RandomNumberGenerator {
     fn next_u32(&mut self) -> u32 {
         rand_core::impls::next_u32_via_fill(self)
     }
+
     fn next_u64(&mut self) -> u64 {
         rand_core::impls::next_u64_via_fill(self)
     }
+
     fn fill_bytes(&mut self, dst: &mut [u8]) {
         // Panics are allowed in `fill_bytes`
         self.try_fill_bytes(dst).unwrap()
     }
+
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), rand_core::Error> {
         self.gen_random(dst)
             .map_err(|e| From::<core::num::NonZeroU32>::from(e.into()))


### PR DESCRIPTION
Implement CryptoRng + RngCore for the random number generator provided
by the CNG so that we can use it whenever downstream users rely on the
interface traits provided by the `rand` crate.