### PR TITLE
Implement BlockCipher trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - ""
           - "zeroize"
           - "rand"
+          - "block-cipher"
         exclude: # Zeroize 1.1 supports Rust 1.39+
           - rust: 1.37.0
             features: "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ maintenance = { status = "experimental" }
 winapi = { version = "0.3", features = ["bcrypt", "ntstatus", "winerror"] }
 zeroize = { version = "1.1", optional = true }
 rand_core = { version = "0.5", optional = true }
+block-cipher = { version = "0.8", optional = true }
 doc-comment = "0.3"
 
 [dev-dependencies]
@@ -26,6 +27,7 @@ doc-comment = "0.3"
 [features]
 default = ["zeroize"]
 rand = ["rand_core"]
+block-cipher-trait = ["block-cipher"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ doc-comment = "0.3"
 [features]
 default = ["zeroize"]
 rand = ["rand_core"]
-block-cipher-trait = ["block-cipher"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Windows, you already accepted to trust these primitives.
 
 *More to come*
 
+## Cargo features
+
+- `zeroize` - Uses `zeroize` crate to zero intermediate buffers on destruction
+- `rand` - Implements `rand` crate traits for the CNG-provided CSPRNG
+  (cryptographically secure pseudorandom number generator)
+- `block-cipher` - Implements `block-cipher` traits for CNG block ciphers.
+
+By default, only the `zeroize` feature is enabled.
+
 ## Examples
 
 ### Asymmetric encryption (RSA)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -45,6 +45,10 @@ impl Buffer {
         }
     }
 
+    pub fn from_vec(data: Vec<u8>) -> Self {
+        Buffer { inner: data }
+    }
+
     pub fn len(&self) -> usize {
         self.inner.len()
     }

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -676,6 +676,16 @@ mod block_cipher_trait {
         _bits: PhantomData<B>,
     }
 
+    impl<A: Algorithm, B: KeyBits> Clone for BlockCipherKey<A, B> {
+        fn clone(&self) -> Self {
+            BlockCipherKey {
+                key: self.key.clone(),
+                _algo: PhantomData,
+                _bits: PhantomData,
+            }
+        }
+    }
+
     impl<A: Algorithm, B: KeyBits> BlockCipherKey<A, B> {
         pub fn into_key(self) -> super::Key<A, B> {
             self.key

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -714,8 +714,8 @@ mod block_cipher_trait {
         }
     }
 
-    use block_cipher::{self, Block, BlockCipher, Key, NewBlockCipher};
     use block_cipher::generic_array::{typenum, ArrayLength};
+    use block_cipher::{self, Block, BlockCipher, Key, NewBlockCipher};
 
     impl<T: typenum::Unsigned> KeyBits for T {
         const VALUE: Option<usize> = Some(Self::USIZE);

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -809,9 +809,9 @@ mod block_cipher_trait {
     }
 
     use typenum::{IsEqual, IsGreaterOrEqual, IsLessOrEqual, PartialDiv};
-    use typenum::{B1, U1, U1024, U128, U16, U256, U64, U8};
-    use typenum::{U112, U168, U184, U56};
+    use typenum::{B1, U1, U128, U16, U192, U256, U64, U8};
 
+    // NOTE: These are values as supported by CNG (tested on Windows 10 2004).
     impl_block_cipher!(
         (Aes, block: U16, par: U1, KeyBits:
             // {128, 192, 256}
@@ -820,20 +820,20 @@ mod block_cipher_trait {
             PartialDiv<U64>
         ),
         (Rc2, block: U8, par: U1, KeyBits:
-            // {8, 16, .., 1024}
-            IsGreaterOrEqual<U8, Output = B1> +
-            IsLessOrEqual<U1024, Output = B1> +
+            // {16, 24, .., 128}
+            IsGreaterOrEqual<U16, Output = B1> +
+            IsLessOrEqual<U128, Output = B1> +
             PartialDiv<U8>
         ),
-        (Des, block: U8, par: U1, KeyBits: IsEqual<U56, Output = B1>),
-        (DesX, block: U8, par: U1, KeyBits: IsEqual<U184, Output = B1>),
-        (TripleDes, block: U8, par: U1, KeyBits:
-            // {112, 168}
-            IsGreaterOrEqual<U112, Output = B1> +
-            IsLessOrEqual<U168, Output = B1> +
-            PartialDiv<U56>
-        ),
-        (TripleDes112, block: U8, par: U1, KeyBits: IsEqual<U112, Output = B1>),
+        (Des, block: U8, par: U1, KeyBits: IsEqual<U64, Output = B1>),
+        (DesX, block: U8, par: U1, KeyBits: IsEqual<U192, Output = B1>),
+        (TripleDes, block: U8, par: U1, KeyBits: IsEqual<U192, Output = B1>),
+        (TripleDes112, block: U8, par: U1, KeyBits:
+            // {128, 192}
+            IsGreaterOrEqual<U128, Output = B1> +
+            IsLessOrEqual<U192, Output = B1> +
+            PartialDiv<U64>
+        )
     );
 }
 
@@ -993,14 +993,14 @@ mod tests {
             (Aes, key: 16),
             (Aes, key: 24),
             (Aes, key: 32),
-            (Rc2, key: 1),
+            (Rc2, key: 2),
             (Rc2, key: 8),
             (Rc2, key: 128),
-            (Des, key: 7),
-            (DesX, key: 23),
-            (TripleDes, key: 14),
-            (TripleDes, key: 21),
-            (TripleDes112, key: 14),
+            (Des, key: 8),
+            (DesX, key: 24),
+            (TripleDes, key: 24),
+            (TripleDes112, key: 16),
+            (TripleDes112, key: 24),
         );
     }
 

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -643,9 +643,9 @@ impl SymmetricAlgorithmKey {
     }
 }
 
-#[cfg(feature = "block-cipher-trait")]
+#[cfg(feature = "block-cipher")]
 pub use block_cipher;
-#[cfg(feature = "block-cipher-trait")]
+#[cfg(feature = "block-cipher")]
 mod block_cipher_trait {
     use super::*;
 
@@ -835,7 +835,7 @@ mod tests {
         assert_eq!(expected_block_size, key.block_size().unwrap());
     }
 
-    #[cfg(feature = "block-cipher-trait")]
+    #[cfg(feature = "block-cipher")]
     fn _assert_aes_keysize_valid() {
         use block_cipher::{generic_array::typenum, NewBlockCipher};
         fn _assert_trait_impl<T: NewBlockCipher>() {}
@@ -844,7 +844,7 @@ mod tests {
         _assert_trait_impl::<super::Key<Aes, typenum::U256>>();
     }
 
-    #[cfg(feature = "block-cipher-trait")]
+    #[cfg(feature = "block-cipher")]
     #[test]
     fn cipher_trait() {
         use core::convert::TryFrom;
@@ -868,7 +868,7 @@ mod tests {
         typed.decrypt_block(GenericArray::from_mut_slice(data.as_mut()));
     }
 
-    #[cfg(feature = "block-cipher-trait")]
+    #[cfg(feature = "block-cipher")]
     #[test]
     fn marker_bits() {
         use block_cipher::generic_array::typenum;

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -662,7 +662,7 @@ mod block_cipher_trait {
     };
     use block_cipher::{self, Block, BlockCipher, Key, NewBlockCipher};
 
-    impl<T> KeyBits for T where T: typenum::Unsigned {
+    impl<T: typenum::Unsigned> KeyBits for T {
         const VALUE: Option<usize> = Some(Self::USIZE);
     }
 

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -667,14 +667,6 @@ mod block_cipher_trait {
         const VALUE: Option<usize> = Some(Self::USIZE);
     }
 
-    #[test]
-    fn assert_aes_keysize_valid() {
-        fn _inner<T: NewBlockCipher>() {}
-        _inner::<super::Key<Aes, typenum::U128>>();
-        _inner::<super::Key<Aes, typenum::U192>>();
-        _inner::<super::Key<Aes, typenum::U256>>();
-    }
-
     impl<B: KeyBits> NewBlockCipher for super::Key<Aes, B>
     where
         B: typenum::Unsigned,
@@ -841,6 +833,15 @@ mod tests {
         assert_eq!(data, &plaintext.as_slice()[..data.len()]);
         assert_eq!(secret.len() * 8, key.key_size().unwrap());
         assert_eq!(expected_block_size, key.block_size().unwrap());
+    }
+
+    #[cfg(feature = "block-cipher-trait")]
+    fn _assert_aes_keysize_valid() {
+        use block_cipher::{generic_array::typenum, NewBlockCipher};
+        fn _assert_trait_impl<T: NewBlockCipher>() {}
+        _assert_trait_impl::<super::Key<Aes, typenum::U128>>();
+        _assert_trait_impl::<super::Key<Aes, typenum::U192>>();
+        _assert_trait_impl::<super::Key<Aes, typenum::U256>>();
     }
 
     #[cfg(feature = "block-cipher-trait")]

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -695,8 +695,8 @@ mod block_cipher_trait {
     impl<A: Algorithm, B: KeyBits> super::Key<A, B> {
         /// Returns a helper type that implements [`block_cipher::BlockCipher`] trait.
         ///
-        /// Returns `Ok` iff the underlying key is set to ECB chaining mode, see
-        /// [`BlockCipherKey`] for more details.
+        /// Returns `Ok` if and only if the underlying key is set to ECB
+        /// chaining mode, see [`BlockCipherKey`] for more details.
         ///
         /// [`BlockCipherKey`]: struct.BlockCipherKey.html
         /// [`block_cipher::BlockCipher`]: ../../block_cipher/trait.BlockCipher.html

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -241,10 +241,15 @@ pub trait KeyBits {
     /// Value known at compile-time, `None` if only known at run-time.
     const VALUE: Option<usize> = None;
 }
-impl KeyBits for () {}
+/// Key length known at run-time.
+pub struct DynamicKeyBits;
+
+impl KeyBits for DynamicKeyBits {
+    const VALUE: Option<usize> = None;
+}
 
 /// Handle to a symmetric key.
-pub struct Key<A: Algorithm, B: KeyBits = ()> {
+pub struct Key<A: Algorithm, B: KeyBits = DynamicKeyBits> {
     inner: SymmetricAlgorithmKey,
     _algo: PhantomData<A>,
     _bits: PhantomData<B>,
@@ -652,18 +657,12 @@ mod block_cipher_trait {
     use core::convert::TryFrom;
 
     use block_cipher::generic_array::{
-        typenum::{self, Unsigned},
+        typenum::{self},
         ArrayLength,
     };
     use block_cipher::{self, Block, BlockCipher, Key, NewBlockCipher};
 
-    impl KeyBits for typenum::U128 {
-        const VALUE: Option<usize> = Some(Self::USIZE);
-    }
-    impl KeyBits for typenum::U192 {
-        const VALUE: Option<usize> = Some(Self::USIZE);
-    }
-    impl KeyBits for typenum::U256 {
+    impl<T> KeyBits for T where T: typenum::Unsigned {
         const VALUE: Option<usize> = Some(Self::USIZE);
     }
 


### PR DESCRIPTION
This implements the `BlockCipher` trait from the https://github.com/RustCrypto/traits interface, so that we can use the CNG as the underlying block cipher for other cryptographic primitives in Rust. The primary motivation is to use it for the EAX mode (authenticated encryption) in the [`eax`](https://crates.io/crates/eax) crate (currently moved under the [RustCrypto/AEADs](https://github.com/RustCrypto/AEADs/tree/master/eax) umbrella repository).

This is a WIP PR outlining the proposed changes. As it was done in my asymmetric-related PRs, this also exposes the supported algorithm to a compile-time enumeration - the reason for that is some RustCrypto traits require block size at the compile-time and so we need to also know here which algorithm we're using at the compile-time as well.

This introduces basically the same mechanism for `SymmetricAlgorithmId` and `Algorithm` trait - maybe it'd make sense to introduce a generic trait for usage with asymmetric/symmetric/hash/other? domains? Something like:
```rust
pub trait Algorithm<Id> {
    // e.g. e.g. `Some(Aes)` or `None` for the runtime-dispatched enum like `SymmetricAlgorithmId`
    // To be used in compile-time
    const ID: Option<Id>;
    // Returns a type-erased ID value, e.g. `SymmetricAlgorithmId`
    // To be used at run-time
    fn id(&self) -> Id;

    // Maybe this might be useful (either for internal or public usage) as well?
    fn name(&self) -> &str { self.id().as_str() }
}

// ...

pub struct SymmetricKey<A: Algorithm<Id = SymmetricAlgorithmId>> { /* ... */ }
// ...now that I just wrote it, I'm not sure that bounds for algorithm with specified associated types are
// possible/stable - will need to investigate that
```

@emgre what do you think?