### PR TITLE
Add digest trait implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ winapi = { version = "0.3", features = ["bcrypt", "ntstatus", "winerror"] }
 zeroize = { version = "1.1", optional = true }
 rand_core = { version = "0.5", optional = true }
 block-cipher = { version = "0.8", optional = true }
-digest = "0.9.0"
+digest = { version = "0.9.0", optional = true }
 doc-comment = "0.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ winapi = { version = "0.3", features = ["bcrypt", "ntstatus", "winerror"] }
 zeroize = { version = "1.1", optional = true }
 rand_core = { version = "0.5", optional = true }
 block-cipher = { version = "0.8", optional = true }
+digest = "0.9.0"
 doc-comment = "0.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Windows, you already accepted to trust these primitives.
 - `rand` - Implements `rand` crate traits for the CNG-provided CSPRNG
   (cryptographically secure pseudorandom number generator)
 - `block-cipher` - Implements `block-cipher` traits for CNG block ciphers.
+- `digest` - Implements `digest` traits for CNG hashing algorithms.
 
 By default, only the `zeroize` feature is enabled.
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -466,6 +466,7 @@ impl Clone for Hash {
     }
 }
 
+#[cfg(feature = "digest")]
 pub mod digest_trait {
     use super::{Hash, HashAlgorithm, HashAlgorithmId};
     use digest::generic_array::{typenum, ArrayLength, GenericArray};

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -471,12 +471,14 @@ pub mod digest_trait {
     use digest::generic_array::{typenum, ArrayLength, GenericArray};
     use std::marker::PhantomData;
 
+    /// Helper trait for [`digest::Digest`] implementations.
     pub trait WinDigestAlgo: Clone {
         type BlockSize: ArrayLength<u8>;
         type OutputSize: ArrayLength<u8>;
         fn algo_id() -> HashAlgorithmId;
     }
 
+    /// Helper struct that implements [`digest::Digest`] trait.
     #[derive(Clone)]
     pub struct WinDigest<A> {
         _algo: PhantomData<A>,
@@ -536,8 +538,15 @@ pub mod digest_trait {
             }
         };
     }
+
+    impl_win_digest!(Md2, typenum::U16, typenum::U16, Md2);
+    impl_win_digest!(Md4, typenum::U64, typenum::U16, Md4);
     impl_win_digest!(Md5, typenum::U64, typenum::U16, Md5);
+
     impl_win_digest!(Sha1, typenum::U64, typenum::U20, Sha1);
+    impl_win_digest!(Sha256, typenum::U64, typenum::U32, Sha256);
+    impl_win_digest!(Sha384, typenum::U128, typenum::U48, Sha384);
+    impl_win_digest!(Sha512, typenum::U128, typenum::U64, Sha512);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows primitives in this crate to be used with things like `Hmac` (I tried to do HMAC-MD5 directly within CNG, but has no success as for now, so opted for this).