### PR TITLE
Move away from the deprecated block-cipher crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 winapi = { version = "0.3", features = ["bcrypt", "ntstatus", "winerror"] }
 zeroize = { version = "1.1", optional = true }
 rand_core = { version = "0.5", optional = true }
-block-cipher = { version = "0.8", optional = true }
+cipher = { version = "0.2.5", optional = true }
 doc-comment = "0.3"
 
 [dev-dependencies]
@@ -27,6 +27,7 @@ doc-comment = "0.3"
 [features]
 default = ["zeroize"]
 rand = ["rand_core"]
+block-cipher = ["cipher"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -661,9 +661,9 @@ impl SymmetricAlgorithmKey {
 }
 
 #[cfg(feature = "block-cipher")]
-pub use block_cipher;
-#[cfg(feature = "block-cipher")]
 pub use block_cipher_trait::BlockCipherKey;
+#[cfg(feature = "block-cipher")]
+pub use cipher::block as block_cipher;
 #[cfg(feature = "block-cipher")]
 mod block_cipher_trait {
     use super::*;


### PR DESCRIPTION
See RustCrypto/traits#337, This should be a drop-in replacement.