### PR TITLE
Don't block on Clippy warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --no-default-features --features "${{ matrix.features }}" -- -D warnings
+        args: --no-default-features --features "${{ matrix.features }}"

--- a/src/key_blob.rs
+++ b/src/key_blob.rs
@@ -99,7 +99,7 @@ pub unsafe trait KeyBlob: Sized {
     const VALID_MAGIC: &'static [ULONG];
 
     fn is_magic_valid(magic: ULONG) -> bool {
-        let accepts_all = Self::VALID_MAGIC == [];
+        let accepts_all = Self::VALID_MAGIC.is_empty();
         accepts_all || Self::VALID_MAGIC.iter().any(|&x| x == magic)
     }
 }


### PR DESCRIPTION
Sometimes new nightly Clippy builds can introduce lints that were previously accepted - if we deny all by default, then we block the entire pipeline on Clippy warnings, which can cause unnecessary churn on unrelated PRs (e.g. asking everyone to rebase or fix the lint introduced in the meantime in an unrelated PR).

For some time now GitHub parses the warnings from CI and leaves annotations in the file view itself, so that should be enough of a visible warning that can be fixed in the meantime, without blocking other PRs.

@emgre could you sign off on it, please?