### PR TITLE
Remove `doc-comment` from the dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ winapi = { version = "0.3", features = ["bcrypt", "ntstatus", "winerror"] }
 zeroize = { version = "1.1", optional = true }
 rand_core = { version = "0.5", optional = true }
 cipher = { version = "0.2.5", optional = true }
-doc-comment = "0.3"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use doc_comment::doctest;
 use winapi::shared::ntdef::NTSTATUS;
 use winapi::shared::ntstatus;
 
@@ -16,7 +15,8 @@ pub mod symmetric;
 pub mod helpers;
 
 // Compile and test the README
-doctest!("../README.md");
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
 
 /// Error type
 ///


### PR DESCRIPTION
❗**WARNING**❗ This change bumps the MSRV to 1.40.

Fix #8.