### PR TITLE
Bump cipher to 0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 winapi = { version = "0.3", features = ["bcrypt", "ntstatus", "winerror"] }
 zeroize = { version = "1.1", optional = true }
 rand_core = { version = "0.5", optional = true }
-cipher = { version = "0.2.5", optional = true }
+cipher = { version = "0.4.3", optional = true }
 doc-comment = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Closes #41 

`cipher` 0.4 refactored block cipher traits. Specifically,

- `NewBlockCipher` is now `KeyInit`, also requiring `KeySizeUser`

- `BlockCipher` is now `BlockEncrypt + BlockDecrypt`. `BlockCipher` still exists as a marker trait. They additionally require `BlockSizeUser`.

Implementing `BlockCipher + BlockEncrypt + BlockDecrypt + KeyInit` appears to satisfy idiomatic trait bounds, see [`eax::online::Eax`](https://docs.rs/eax/latest/eax/online/struct.Eax.html) for an example.

As the trait implementations are exposed to the user, these changes would require a breaking release of win-crypto-ng.