### PR TITLE
Stop taking unaligned references to packed fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.37.0  # MSRV
+          - 1.60.0  # MSRV
           - stable
           - beta
           - nightly
@@ -15,9 +15,6 @@ jobs:
           - "zeroize"
           - "rand"
           - "block-cipher"
-        exclude: # Zeroize 1.1 supports Rust 1.39+
-          - rust: 1.37.0
-            features: "zeroize"
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "win-crypto-ng"
 version = "0.4.0"
 authors = ["Émile Grégoire <eg@emilegregoire.ca>", "Igor Matuszewski <Xanewok@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Safe bindings to Windows Cryptography API: Next Generation"
 repository = "https://github.com/emgre/win-crypto-ng"
 documentation = "https://docs.rs/crate/win-crypto-ng"
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["cng", "windows", "cryptoapi"]
 categories = ["api-bindings", "os::windows-apis", "cryptography"]
 license = "BSD-3-Clause"
+rust-version = "1.60"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/win-crypto-ng.svg)](https://crates.io/crates/win-crypto-ng)
 [![docs.rs](https://docs.rs/win-crypto-ng/badge.svg)](https://docs.rs/crate/win-crypto-ng)
-![MSRV](https://img.shields.io/badge/rustc-1.37+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.60+-blue.svg)
 [![Build status](https://github.com/emgre/win-crypto-ng/workflows/CI/badge.svg)](https://github.com/emgre/win-crypto-ng/actions)
 [![License](https://img.shields.io/github/license/emgre/win-crypto-ng)](https://github.com/emgre/win-crypto-ng/blob/master/LICENSE.md)
 

--- a/src/helpers/blob.rs
+++ b/src/helpers/blob.rs
@@ -71,9 +71,7 @@ unsafe impl<T: BlobLayout> FromBytes for Blob<T> {
     // Require that the allocation is at least as aligned as its header to
     // safely reference it as the first field. (despite
     // `Blob` being technically `#[repr(packed)]`)
-    unsafe fn min_layout() -> Layout {
-        Layout::new::<T::Header>()
-    }
+    const MIN_LAYOUT: Layout = Layout::new::<T::Header>();
 
     unsafe fn ptr_cast(source: *const [u8]) -> *const Self {
         assert_ne!(source as *const (), ptr::null());

--- a/src/helpers/blob.rs
+++ b/src/helpers/blob.rs
@@ -4,6 +4,7 @@ use crate::helpers::{AsBytes, FromBytes};
 
 use core::alloc::Layout;
 use core::{mem, ptr, slice};
+use std::ptr::addr_of;
 
 /// C-compatible dynamic inline structure.
 ///
@@ -33,9 +34,11 @@ impl<'a, T: BlobLayout> Blob<T> {
         // `Self::from_boxed`, which requires that the source reference is
         // aligned at least as `T::Header` and since `Blob` is
         // `#[repr(C)]` (and so is `T::Header`, because it  implements `AsBytes`
-        // which requires being `#[repr(C)]`), so the reference to its first
-        // field will be aligned at least as `T::Header`.
-        unsafe { &self.0 }
+        // which requires being `#[repr(C)]`), so the pointer to its first
+        // field will be aligned at least as `T::Header`, and can be safely
+        // cast to a reference
+        let header_ptr = addr_of!(self.0);
+        unsafe { &*header_ptr }
     }
 
     pub(crate) fn tail(&self) -> &[u8] {

--- a/src/helpers/blob.rs
+++ b/src/helpers/blob.rs
@@ -134,11 +134,11 @@ macro_rules! blob {
                 let mut boxed = vec![0u8; header_len + tail_len].into_boxed_slice();
 
                 let header_bytes = $crate::helpers::AsBytes::as_bytes(header);
-                &mut boxed[..header_len].copy_from_slice(header_bytes);
+                boxed[..header_len].copy_from_slice(header_bytes);
                 let mut offset = header_len;
                 $(
                     let field_len = blob! { size: header, $($len)*};
-                    &mut boxed[offset..offset + field_len].copy_from_slice(tail.$field);
+                    boxed[offset..offset + field_len].copy_from_slice(tail.$field);
                     offset += field_len;
                 )*
 

--- a/src/helpers/blob.rs
+++ b/src/helpers/blob.rs
@@ -49,9 +49,6 @@ impl<'a, T: BlobLayout> Blob<T> {
         AsBytes::as_bytes(self)
     }
 
-    // False positive for arbitrary self type
-    // TODO: Remove once we bump MSRV to a newer clippy
-    #[allow(clippy::wrong_self_convention)]
     pub fn into_bytes(self: Box<Self>) -> Box<[u8]> {
         AsBytes::into_bytes(self)
     }

--- a/src/helpers/bytes.rs
+++ b/src/helpers/bytes.rs
@@ -87,7 +87,7 @@ pub unsafe trait FromBytes {
     fn from_bytes(bytes: &[u8]) -> &Self {
         let min_layout = unsafe { Self::min_layout() };
         // Make sure the allocation meets the expected layout requirements
-        assert!(bytes.len() >= min_layout.size(), 0);
+        assert!(bytes.len() >= min_layout.size());
         assert_eq!(bytes.as_ptr() as usize % min_layout.align(), 0);
 
         let old_size = mem::size_of_val(bytes);
@@ -106,7 +106,7 @@ pub unsafe trait FromBytes {
     fn from_boxed(boxed: Box<[u8]>) -> Box<Self> {
         let min_layout = unsafe { Self::min_layout() };
         // Make sure the allocation meets the expected layout requirements
-        assert!(boxed.len() >= min_layout.size(), 0);
+        assert!(boxed.len() >= min_layout.size());
         assert_eq!(boxed.as_ptr() as usize % min_layout.align(), 0);
 
         let old_size = mem::size_of_val(boxed.as_ref());


### PR DESCRIPTION
Closes #40 

Taking a reference to a `repr(packed)` field no longer compiles under a [deny-by-default lint](https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#unaligned-references). This PR avoids taking the reference. Instead, we get a pointer using `addr_of` and then cast this to a reference, which is sound under pre-exisiting alignment invariants.

Updates MSRV to 1.60.