### PR TITLE
Add safety documentation for X::clone_from_parts.

### DIFF
--- a/src/asymmetric/mod.rs
+++ b/src/asymmetric/mod.rs
@@ -304,9 +304,9 @@ impl AsymmetricKey<Rsa, Private> {
     /// Export the RSA key to "full" raw data format. Additionally includes
     /// coefficient and (private) exponents.
     pub fn export_full(&self) -> Result<Box<Blob<RsaKeyFullPrivateBlob>>> {
-        Ok(KeyPair::export(self.0.handle, BlobType::RsaFullPrivate)?
+        KeyPair::export(self.0.handle, BlobType::RsaFullPrivate)?
             .try_into()
-            .map_err(|_| crate::Error::BadData)?)
+            .map_err(|_| crate::Error::BadData)
     }
 }
 
@@ -365,7 +365,7 @@ impl AsymmetricKey<Rsa, Private> {
         parts: &RsaKeyPrivatePayload,
     ) -> Result<Self> {
         let key_bits = parts.modulus.len() * 8;
-        if key_bits % 64 != 0 || key_bits < 512 || key_bits > 16384 {
+        if key_bits % 64 != 0 || !(512..=16384).contains(&key_bits) {
             return Err(crate::Error::InvalidParameter);
         }
 
@@ -389,7 +389,7 @@ impl AsymmetricKey<Rsa, Public> {
         parts: &RsaKeyPublicPayload,
     ) -> Result<Self> {
         let key_bits = parts.modulus.len() * 8;
-        if key_bits % 64 != 0 || key_bits < 512 || key_bits > 16384 {
+        if key_bits % 64 != 0 || !(512..=16384).contains(&key_bits) {
             return Err(crate::Error::InvalidParameter);
         }
 
@@ -783,7 +783,7 @@ pub trait Export<A: Algorithm, P: Parts>: Borrow<AsymmetricKey<A, P>> {
         let blob_type = self.blob_type();
 
         let blob = KeyPair::export(key.0.handle, blob_type)?;
-        Ok(blob.try_into().map_err(|_| crate::Error::BadData)?)
+        blob.try_into().map_err(|_| crate::Error::BadData)
     }
 }
 
@@ -835,7 +835,7 @@ pub enum DsaPublicBlob {
     V2(Box<Blob<DsaKeyPublicV2Blob>>),
 }
 
-impl<'a> AsRef<Blob<ErasedKeyBlob>> for DsaPublicBlob {
+impl AsRef<Blob<ErasedKeyBlob>> for DsaPublicBlob {
     fn as_ref(&self) -> &Blob<ErasedKeyBlob> {
         match self {
             DsaPublicBlob::V1(v1) => v1.as_erased(),
@@ -852,7 +852,7 @@ pub enum DsaPrivateBlob {
     V2(Box<Blob<DsaKeyPrivateV2Blob>>),
 }
 
-impl<'a> AsRef<Blob<ErasedKeyBlob>> for DsaPrivateBlob {
+impl AsRef<Blob<ErasedKeyBlob>> for DsaPrivateBlob {
     fn as_ref(&self) -> &Blob<ErasedKeyBlob> {
         match self {
             DsaPrivateBlob::V1(v1) => v1.as_erased(),
@@ -885,7 +885,7 @@ struct OaepPaddingInfo<'a> {
 }
 
 impl OaepPadding {
-    fn to_ffi_args<'a>(&self, out: &'a mut WindowsString) -> OaepPaddingInfo {
+    fn to_ffi_args(&self, out: &mut WindowsString) -> OaepPaddingInfo {
         *out = WindowsString::from(self.algorithm.to_str());
         OaepPaddingInfo {
             _borrowed: self,

--- a/src/asymmetric/signature.rs
+++ b/src/asymmetric/signature.rs
@@ -124,6 +124,7 @@ union PaddingInfo<'a> {
 }
 
 impl SignaturePadding {
+    #[allow(clippy::wrong_self_convention)]
     fn to_ffi_args<'a>(&self, out: &'a mut WindowsString) -> (PaddingInfo<'a>, u32) {
         match self {
             SignaturePadding::Pkcs1(Pkcs1Padding { algorithm }) => {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,6 @@
 //! Secure buffer implementation
 
 use std::fmt::{Debug, Error, Formatter};
-use std::mem;
 
 /// Secure buffer implementation.
 ///
@@ -74,7 +73,7 @@ impl Buffer {
     }
 
     pub fn into_inner(mut self) -> Vec<u8> {
-        mem::replace(&mut self.inner, Vec::new())
+        std::mem::take(&mut self.inner)
     }
 }
 

--- a/src/helpers/blob.rs
+++ b/src/helpers/blob.rs
@@ -28,7 +28,7 @@ pub trait BlobLayout {
     type Header: AsBytes + FromBytes;
 }
 
-impl<'a, T: BlobLayout> Blob<T> {
+impl<T: BlobLayout> Blob<T> {
     pub fn header(&self) -> &T::Header {
         // SAFETY: The only way to construct `Blob` is via
         // `Self::from_boxed`, which requires that the source reference is
@@ -76,7 +76,7 @@ unsafe impl<T: BlobLayout> FromBytes for Blob<T> {
     unsafe fn ptr_cast(source: *const [u8]) -> *const Self {
         assert_ne!(source as *const (), ptr::null());
         // SAFETY: [u8] is 1-byte aligned so no need to check before deref
-        let len = (&*source).len();
+        let len = (*source).len();
         let tail_len = len - mem::size_of::<T::Header>();
 
         // SAFETY: This assumes that the pointer to slices and slice-based DSTs

--- a/src/helpers/blob.rs
+++ b/src/helpers/blob.rs
@@ -22,8 +22,8 @@ use std::ptr::addr_of;
 #[repr(C, packed)]
 pub struct Blob<T: BlobLayout>(T::Header, [u8]);
 
-/// Marker trait for dynamic struct layouts prefixed with `Self::Header` type
-/// of a statically-known size. Used in tandem with `Blob`.
+/// Marker trait for dynamic struct layouts prefixed with [`Self::Header`] type
+/// of a statically-known size. Used in tandem with [`Blob`].
 pub trait BlobLayout {
     type Header: AsBytes + FromBytes;
 }
@@ -63,14 +63,14 @@ impl<'a, T: BlobLayout> Blob<T> {
 }
 
 // SAFETY: The struct is `#[repr(C)]` and so is the header because it implements
-// `AsBytes` as well, so the layout is well-defined and data can be converted to
+// [`AsBytes`] as well, so the layout is well-defined and data can be converted to
 // bytes
 unsafe impl<T: BlobLayout> AsBytes for Blob<T> {}
 
 unsafe impl<T: BlobLayout> FromBytes for Blob<T> {
     // Require that the allocation is at least as aligned as its header to
     // safely reference it as the first field. (despite
-    // `Blob` being technically `#[repr(packed)]`)
+    // [`Blob`] being technically `#[repr(packed)]`)
     const MIN_LAYOUT: Layout = Layout::new::<T::Header>();
 
     unsafe fn ptr_cast(source: *const [u8]) -> *const Self {
@@ -120,6 +120,12 @@ macro_rules! blob {
         }
 
         impl $crate::helpers::Blob<$wrapper_ident> {
+            /// Create a [`$wrapper_ident`] blob instance from its parts.
+            ///
+            /// SAFETY: The header might contain length information about the payload
+            /// (i.e. the `tail` argument). An mismatch between the two won't cause a
+            /// memory corruption, but it will panic. Careful validation of the
+            /// arguments must be done to ensure proper behaviour.
             #[allow(unused_assignments)]
             pub fn clone_from_parts(header: &$header, tail: &$tail_ident) -> Box<Self> {
                 let header_len = core::mem::size_of_val(header);

--- a/src/helpers/bytes.rs
+++ b/src/helpers/bytes.rs
@@ -27,7 +27,7 @@ pub(crate) fn ptr_ref_cast<T, U>(ptr: *const U) -> *const T {
 pub unsafe fn ptr_slice_cast<T>(ptr: *const [u8]) -> *const [T] {
     assert_ne!(ptr as *const (), ptr::null());
     // SAFETY: [u8] is 1-byte aligned so no need to check that before deref
-    let len = (&*ptr).len();
+    let len = (*ptr).len();
 
     let new_len = len * mem::size_of::<u8>() / mem::size_of::<T>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@ impl Error {
     }
 }
 
-impl Into<NonZeroU32> for Error {
-    fn into(self) -> NonZeroU32 {
-        let code: i32 = match self {
+impl From<Error> for NonZeroU32 {
+    fn from(val: Error) -> Self {
+        let code: i32 = match val {
             Error::NotFound => ntstatus::STATUS_NOT_FOUND,
             Error::InvalidParameter => ntstatus::STATUS_INVALID_PARAMETER,
             Error::BufferTooSmall => ntstatus::STATUS_BUFFER_TOO_SMALL,
@@ -88,7 +88,7 @@ impl Into<NonZeroU32> for Error {
             Error::Unknown(value) => value,
         };
 
-        NonZeroU32::new(code.abs() as u32).expect("Error to not be STATUS_SUCCESS")
+        NonZeroU32::new(code.unsigned_abs()).expect("Error to not be STATUS_SUCCESS")
     }
 }
 

--- a/src/property.rs
+++ b/src/property.rs
@@ -149,10 +149,11 @@ impl Property for MessageBlockLength {
 /// **DWORD**. Currently, the hash and symmetric cipher algorithm providers use
 /// caller-allocated buffers to store their subobjects. For example, the hash
 /// provider requires you to allocate memory for the hash object obtained with
-/// the [BCryptCreateHash] function. This property provides the buffer size for a
+/// the [`BCryptCreateHash`] function. This property provides the buffer size for a
 /// provider's object so you can allocate memory for the object created by the
 /// provider.
-/// [BCryptCreateHash]: https://docs.microsoft.com/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash
+///
+/// [`BCryptCreateHash`]: <https://docs.microsoft.com/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash>
 pub enum ObjectLength {}
 impl Property for ObjectLength {
     const IDENTIFIER: &'static str = bcrypt::BCRYPT_OBJECT_LENGTH;

--- a/src/random.rs
+++ b/src/random.rs
@@ -86,9 +86,9 @@ impl<'a> TryFrom<&'a str> for RandomAlgorithmId {
     }
 }
 
-impl Into<&'static str> for RandomAlgorithmId {
-    fn into(self) -> &'static str {
-        match self {
+impl From<RandomAlgorithmId> for &'static str {
+    fn from(val: RandomAlgorithmId) -> Self {
+        match val {
             RandomAlgorithmId::Rng => BCRYPT_RNG_ALGORITHM,
             RandomAlgorithmId::DualECRng => BCRYPT_RNG_DUAL_EC_ALGORITHM,
             RandomAlgorithmId::Fips186DsaRng => BCRYPT_RNG_FIPS186_DSA_ALGORITHM,


### PR DESCRIPTION
Also fixed lots of clippy warnings and some doc links.

Fix #44.