### PR TITLE
Bump rand_core to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 winapi = { version = "0.3", features = ["bcrypt", "ntstatus", "winerror"] }
 zeroize = { version = "1.1", optional = true }
-rand_core = { version = "0.5", optional = true }
+rand_core = { version = ">= 0.5, <0.7", optional = true }
 cipher = { version = "0.4.4", optional = true }
 doc-comment = "0.3"
 


### PR DESCRIPTION
Hi @emgre! :wave: 

Quite a few crates in the ecosystem are already using `rand_core` 0.6 (like [`ed25519-dalek` 2.0](https://crates.io/crates/ed25519-dalek/2.0.0/dependencies)). To be able to generate keys there using [`win_crypto_ng::random::RandomNumberGenerator::system_preferred`](https://docs.rs/win-crypto-ng/latest/win_crypto_ng/random/struct.RandomNumberGenerator.html#method.system_preferred) API an upgrade of `rand_core` is needed.

`rand_core` 0.6 was released [2 years ago](https://crates.io/crates/rand_core/versions).